### PR TITLE
Fix chain information types

### DIFF
--- a/models/chain-information.ts
+++ b/models/chain-information.ts
@@ -22,7 +22,7 @@ export type PricingProvidersConfig = {
   [K in PricingProvider]?: PricingProviderConfig<K>;
 };
 
-export const validProviderTypes = ['coingecko'];
+export const validProviderTypes = ['coingecko'] as const;
 
 export type PricingProvider = typeof validProviderTypes[number];
 


### PR DESCRIPTION
Needed for the generics to properly narrow type of `PricingProvidersConfig`.